### PR TITLE
Modified subtitle_generation() function to have an argument called response

### DIFF
--- a/Subtitle Generator.ipynb
+++ b/Subtitle Generator.ipynb
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def subtitle_generation(speech_to_text_response, bin_size=3):\n",
+    "def subtitle_generation(response, bin_size=3):\n",
     "    \"\"\"We define a bin of time period to display the words in sync with audio. \n",
     "    Here, bin_size = 3 means each bin is of 3 secs. \n",
     "    All the words in the interval of 3 secs in result will be grouped togather.\"\"\"\n",
@@ -270,7 +270,7 @@
    ],
    "source": [
     "gcs_uri = f\"gs://{BUCKET_NAME}/{blob_name}\"\n",
-    "response=long_running_recognize(gcs_uri, channels, sample_rate)"
+    "the_response = long_running_recognize(gcs_uri, channels, sample_rate)"
    ]
   },
   {
@@ -279,7 +279,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subtitles= subtitle_generation(response)"
+    "subtitles = subtitle_generation(the_response)"
    ]
   },
   {
@@ -316,7 +316,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi 

Thanks for creating this and writing a blog post to explain it. It's proved very useful for me creating a program to create some srt based subtitle files for videos.

I noticed when working through the code that the `subtitle_generation()` function takes an argument called `speech_to_text_response` but then in the body of the function it uses an object called `response` instead. It appears to work as `response` is actually in the global namespace so it finds it and uses that, ignoring the argument. I've changed the name of the argument to be `response` and then also modified the global object called `response` changing its name to `the_response` to make it clearer that we're trying to use the argument.

Hope that makes sense and thanks again for the blog post.
Dave